### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-PagerBot [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/stripe/pagerbot) [![Build Status](https://travis-ci.org/stripe/pagerbot.svg?branch=master)](https://travis-ci.org/stripe/pagerbot)
+PagerBot [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/stripe/pagerbot) [![Build Status](https://travis-ci.org/stripe/pagerbot.svg?branch=master)](https://travis-ci.org/stripe/pagerbot) [![Inline docs](http://inch-ci.org/github/stripe/pagerbot.svg?branch=master)](http://inch-ci.org/github/stripe/pagerbot)
 ========
 
 Pagerbot is a bot that makes managing [PagerDuty](http://www.pagerduty.com/) on-call schedules easier. It currently supports IRC and slack, and can be easily deployed to heroku. 


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to potential contributors: [![Inline docs](http://inch-ci.org/github/stripe/pagerbot.png)](http://inch-ci.org/github/stripe/pagerbot)

The badge links to [Inch CI](http://inch-ci.org), a project that tries to raise the visibility of inline-docs to encourage aspiring Rubyists to document their code. Your status page is http://inch-ci.org/github/stripe/pagerbot/

Inch CI is still in its infancy (3 months old), but already used by projects like [Bundler](https://github.com/bundler/bundler), [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [ROM](https://github.com/rom-rb/rom).

What do you think?