### PR TITLE
Add Hipchat Support

### DIFF
--- a/lib/admin/admin_server.rb
+++ b/lib/admin/admin_server.rb
@@ -94,7 +94,8 @@ module PagerBot
       },
       slack: {
         emoji: ':frog:'
-      }
+      },
+      hipchat: {}
     }
 
     get '/bot' do
@@ -121,7 +122,7 @@ module PagerBot
       content_type :json
 
       available = PagerBot::PluginManager
-        .available_plugins.sort.map do |name| 
+        .available_plugins.sort.map do |name|
           ret = PagerBot::PluginManager.info name
           plugin = db['plugins'].find_one({name:name})
           if plugin
@@ -135,7 +136,7 @@ module PagerBot
           ret
         end
 
-      { 
+      {
         plugins: available
       }.to_json
     end

--- a/lib/pagerbot.rb
+++ b/lib/pagerbot.rb
@@ -12,6 +12,7 @@ require_relative './pagerbot/pagerduty'
 require_relative './pagerbot/parsing'
 require_relative './pagerbot/action_manager'
 require_relative './pagerbot/slack_adapter'
+require_relative './pagerbot/hipchat_adapter'
 require_relative './pagerbot/irc_adapter'
 require_relative './pagerbot/plugin/plugin_manager'
 
@@ -96,13 +97,17 @@ if __FILE__ == $0
   PagerBot.log.info("Is_admin is "+is_admin.to_s)
   if is_admin
     PagerBot::AdminPage.run!
-  elsif ARGV.first.include?('slack') || ARGV.first.include?('web')
+  elsif ARGV.first.include?('web')
     PagerBot.reload_configuration!
-    PagerBot::SlackAdapter.run!
+    if ARGV.first.include?('slack') || configatron.bot.adapter == 'slack'
+      PagerBot::SlackAdapter.run!
+    elsif ARGV.first.include?('hipchat') || configatron.bot.adapter == 'hipchat'
+      PagerBot::HipchatAdapter.run!
+    end
   elsif ARGV.first.include? 'irc'
     PagerBot.reload_configuration!
     PagerBot::IrcAdapter.run!
   else
-    raise "Could not find adapter #{ARGV.first}. It must be either 'irc' or 'slack'"
+    raise "Could not find adapter #{ARGV.first}. It must be either 'irc', 'slack' or 'hipchat'"
   end
 end

--- a/lib/pagerbot/hipchat_adapter.rb
+++ b/lib/pagerbot/hipchat_adapter.rb
@@ -1,0 +1,197 @@
+# HipChat add-on for pagerbot
+
+require 'json'
+require 'sinatra/base'
+require 'rest-client'
+
+require_relative './datastore'
+
+module PagerBot
+  class HipchatAdapter < Sinatra::Base
+    def db
+      store.db
+    end
+
+    def store
+      @store ||= PagerBot::DataStore.new
+    end
+
+    def base_url(request)
+      "#{request.env['rack.url_scheme']}://#{request.env['HTTP_HOST']}"
+    end
+
+    get '/' do
+      content_type :json
+      {
+        "vendor" => {
+          "url" => "https://github.com/stripe/pagerbot",
+          "name" => "Stripe"
+        },
+        "name" => "Pagerbot",
+        "key" => "com.pagerbot.addon",
+        "links" => {
+          "self" => base_url(request)
+        },
+        "capabilities" => {
+          "webhook" => [{
+            "url" => base_url(request) + "/webhook",
+            "event" => "room_message",
+            "pattern" => "^#{configatron.bot.name}"
+          }],
+          "hipchatApiConsumer" => {
+            "scopes" => [
+              "send_notification",
+              "send_message"
+            ],
+            "fromName" => configatron.bot.name
+          },
+          "installable" => {
+            "allowGlobal" => true,
+            "allowRoom" => false,
+            "callbackUrl" => base_url(request) + "/get_oauth_credentials"
+          }
+        },
+        "description" => "Manage Pagerduty on-call schedules from within HipChat"
+      }.to_json
+    end
+
+    def request_access_token
+      url = "https://#{configatron.bot.hipchat.oauthId}:#{configatron.bot.hipchat.oauthSecret}" \
+            "@api.hipchat.com/v2/oauth/token"
+      PagerBot.log.info "Requesting a HipChat access token."
+      data = {
+        "grant_type" => "client_credentials",
+        "scope" => "send_message send_notification"
+      }
+      begin
+        response = RestClient.post url, data.to_json, :content_type => :json
+      rescue => e
+        PagerBot.log.info e.inspect
+      end
+      response = JSON.parse(response.body)
+      configatron.bot.hipchat.accessToken = response["access_token"]
+      configatron.bot.hipchat.accessToken_expiresIn = response["expires_in"]
+      configatron.bot.hipchat.accessToken_createdAt = Time.now()
+
+      configatron.bot.hipchat.accessToken
+    end
+
+    # https://www.hipchat.com/docs/apiv2/auth#oauth_urls
+    def get_access_token(force=false)
+      if not configatron.bot.hipchat.has_key?(:accessToken) or force
+        request_access_token
+      else
+        expires_in = configatron.bot.hipchat.accessToken_expiresIn
+        created_at = configatron.bot.hipchat.accessToken_createdAt
+        if (Time.now() - created_at) > expires_in
+          request_access_token
+        else
+          configatron.bot.hipchat.accessToken
+        end
+      end
+    end
+
+    post '/get_oauth_credentials' do
+      request_json = JSON.parse request.body.read
+      configatron.bot.hipchat.oauthId = request_json["oauthId"]
+      configatron.bot.hipchat.oauthSecret = request_json["oauthSecret"]
+
+      db['bot'].update({}, {
+        "$set" => {
+          "hipchat.oauthId" => configatron.bot.hipchat.oauthId,
+          "hipchat.oauthSecret" => configatron.bot.hipchat.oauthSecret
+        }
+      }, :upsert => true)
+      get_access_token(true)
+    end
+
+    def get_request_data(request_json)
+      {
+        event: request_json["event"],
+        nick: request_json["item"]["message"]["from"]["mention_name"],
+        room_name: request_json["item"]["room"]["name"],
+        text: request_json["item"]["message"]["message"],
+        message_id: request_json["item"]["message"]["id"],
+        user_id: request_json["item"]["message"]["from"]["id"],
+        adapter: :hipchat
+      }
+    end
+
+    post '/webhook' do
+      request_data = get_request_data JSON.parse request.body.read
+      PagerBot.log.info request_data
+      return "" unless request_data[:event] == "room_message"
+      return "" unless request_data[:text].start_with?(configatron.bot.name+":")
+      return "" unless configatron.bot.channels.include? request_data[:room_name]
+
+      answer = PagerBot.process(request_data[:text], request_data)
+      make_reply answer, request_data
+    end
+
+    delete '/webhook/:id' do
+      if params[:id] == configatron.bot.hipchat.oauthId
+        db['bot'].update({}, {
+          "$unset" => {
+            "hipchat.oauthId" => "",
+            "hipchat.oauthSecret" => ""
+          }
+        }, :upsert => true)
+      end
+      PagerBot.log.info "HipChat add-on uninstalled."
+    end
+
+    get '/ping' do
+      'pong'
+    end
+
+    def make_reply(answer, request_data)
+      if answer[:private_message]
+        # This should be uncommented once HipChat adds support for 1:1 messaging for addons
+        # send_private_message(answer[:private_message], request_data[:user_id])
+        #
+        # For now, we're sending a public message to the room.
+        send_message(answer[:private_message], request_data)
+      end
+
+      unless answer[:message]
+        return ""
+      end
+      send_message(answer[:message], request_data)
+    end
+
+    def send_private_message(message, user_id)
+      data = {
+        message: message,
+      }
+      url = "https://api.hipchat.com/v2/user/#{user_id}/message"
+      send_hipchat_request(data, url)
+    end
+
+    def send_message(message, request_data)
+      data = {
+        message: message,
+        message_format: "text"
+      }
+      url = "https://api.hipchat.com/v2/room/#{request_data[:room_name]}/notification"
+      send_hipchat_request(data, url)
+    end
+
+    def send_hipchat_request(data, url)
+      PagerBot.log.info(data.inspect)
+      params = {:auth_token => get_access_token()}
+      begin
+        resp = RestClient.post(
+          url,
+          data.to_json,
+          :content_type => :json,
+          :params => params
+        )
+      rescue => e
+        PagerBot.log.info e.inspect
+        raise e
+      end
+      PagerBot.log.info resp
+    end
+
+  end
+end

--- a/public/css.css
+++ b/public/css.css
@@ -368,7 +368,7 @@ label.control-label {
   display: inline
 }
 .form-control.very-short {
-  max-width: 6em;
+  max-width: 8em;
   display: inline
 }
 

--- a/public/js/controllers/deploy.js
+++ b/public/js/controllers/deploy.js
@@ -4,6 +4,9 @@ angular.module('pagerbot-admin')
   .controller('DeployCtrl', function ($scope) {
     $scope.app_name = window.location.hostname.split(".")[0];
     $scope.url_base = "https://dashboard.heroku.com/apps/";
+    if (!window.location.origin)
+      window.location.origin = window.location.protocol+"//"+window.location.host;
+    $scope.app_url = window.location.origin;
     if (!$scope.app_name || window.location.hostname.indexOf("herokuapp.com") < 0) {
       $scope.found_app_name = false;
       $scope.dashboard_url = $scope.url_base;

--- a/public/views/bot.html
+++ b/public/views/bot.html
@@ -4,18 +4,18 @@
 
 <section class="content">
   <p class="paragraph">
-    <label class="control-label">Bot name:</label> 
+    <label class="control-label">Bot name:</label>
     <input ng-model="bot.name" class="form-control short" />
     <span class="input-description">
       The nickname that the bot will be addressable by.
     </span>
   </p>
   <div class="paragraph">
-    <label class="control-label">Channels:</label> 
-    
+    <label class="control-label">Channels:</label>
+
     <ul class="single-list">
       <li ng-repeat="chan in bot.channels" class="hollow-badge hollow-badge-green">
-        {{chan}} 
+        {{chan}}
         <a href ng-click="remove_channel(chan, $index)" class="close-button">&times;</a>
       </li>
       <a href ng-click="add_channel()" class="hollow-badge hollow-badge-blue">&plus; <!-- Add another --></a>
@@ -30,10 +30,11 @@
 
 
   <div class="topPad paragraph">
-    <label class="control-label">Chat type:</label> 
+    <label class="control-label">Chat type:</label>
     <select class="form-control very-short" ng-model="bot.adapter">
       <option value="slack">Slack</option>
       <option value="irc">IRC</option>
+      <option value="hipchat">HipChat</option>
     </select>
   </div>
 </section>
@@ -93,11 +94,11 @@
 </section>
 
 <div class="continue-bar">
-  <a href ng-click="goTo('/')" 
+  <a href ng-click="goTo('/')"
     class="btn btn-primary">
     Back
   </a>
-  <a href ng-click="goTo('/plugin-setup')" 
+  <a href ng-click="goTo('/plugin-setup')"
     class="btn btn-primary pull-right">
     Continue
   </a>

--- a/public/views/deploy.html
+++ b/public/views/deploy.html
@@ -9,7 +9,7 @@
 
   <div class="content no-box" ng-show="bot.adapter == 'slack'">
     <p class="paragraph">
-      To deploy a <strong>slackbot</strong>, go to the 
+      To deploy a <strong>slackbot</strong>, go to the
       <a ng-href="{{dashboard_url}}/settings">dashboard settings</a> and
       create a new config variable named <strong>DEPLOYED</strong>, with the value
       set to <strong>true</strong>.
@@ -26,9 +26,30 @@
     </p>
   </div>
 
+  <div class="content no-box" ng-show="bot.adapter == 'hipchat'">
+    <p class="paragraph">
+      To deploy a <strong>HipChat bot</strong>, go to the
+      <a ng-href="{{dashboard_url}}/settings">dashboard settings</a> and
+      create a new config variable named <strong>DEPLOYED</strong>, with the value
+      set to <strong>true</strong>.
+
+      It should look similar to the screenshot below:
+    </p>
+
+    <a ng-href="{{dashboard_url}}/settings" class="paragraph">
+      <img src="pics/slack_example.png" class="paragraph img-responsive">
+    </a>
+    <p class="paragraph">
+      After clicking save, heroku will restart and launch your bot.
+    </p>
+    <p class="paragraph">
+      Once that's done, go to your <a href="https://hipchat.com/admin/addons">HipChat Add-ons page</a> and click on <strong>Build and install your own integration</strong>. Paste <strong><a ng-href="{{app_url}}">{{app_url}}</a></strong> in the modal, and you're all set to go!
+    </p>
+  </div>
+
   <div class="content no-box" ng-show="bot.adapter == 'irc'">
     <p class="paragraph">
-      To deploy an <strong>irc bot</strong>, go to the 
+      To deploy an <strong>irc bot</strong>, go to the
       <a ng-href="{{dashboard_url}}">dashboard</a> and rescale the application to have a single irc worker and nothing else.
 
       It should look similar to the screenshot below:
@@ -53,7 +74,7 @@
 </section>
 
 <div class="continue-bar">
-  <a href ng-click="goTo('/schedule-aliases')" 
+  <a href ng-click="goTo('/schedule-aliases')"
     class="btn btn-primary">
     Back
   </a>


### PR DESCRIPTION
fixes #3.

This is implemented as a [HipChat addon](https://www.hipchat.com/docs/apiv2/addons). 

No copy-paste configuration is needed, all that is handled by a HipChat webhook. Here's a [live demo](https://pagerbothipchat.herokuapp.com/) of the admin app.

When it's time to deploy, one would set `DEPLOYED` to `true` as usual and then go to "https://hipchat.com/admin/addons" and click on Build and install your own integration. After that, he'd paste the URL of the app in the modal, and the configuration will be done automatically. Hipchat sends in the OAuth ID and Secret to a specified URL, and the app manages the rest. :)

![hipchat](https://cloud.githubusercontent.com/assets/3893573/4841479/1781ddd2-601b-11e4-8656-2dcbe327ac7b.png)
