### PR TITLE
Make "911" and "get" consistent

### DIFF
--- a/lib/pagerbot/plugin/call.rb
+++ b/lib/pagerbot/plugin/call.rb
@@ -28,8 +28,30 @@ module PagerBot::Plugins
       # <'911'> TEAM [MESSAGE]
       return unless query[:command] == '911'
 
-      team = query[:words].shift
-      {team: team, message: query[:words].join(' ')}
+      team = []
+      message = []
+      implicit_subject = (query[:words] & ['subject', 'because']).empty?
+
+      parse_stage = :team
+      query[:words].each do |word|
+        case word
+        when 'subject', 'because'
+          parse_stage = :message
+        else
+          case parse_stage
+          when :team
+            team << word
+            if  implicit_subject
+              parse_stage = :message
+            end
+          when :message then message << word
+          end
+        end
+      end
+      {
+        team: team.join(" "),
+        message: message.join(" ")
+      }
     end
 
     +PagerBot::Utilities::DispatchMethod

--- a/test/unit/pagerbot/plugins/call.rb
+++ b/test/unit/pagerbot/plugins/call.rb
@@ -34,6 +34,18 @@ class CallPlugin < Critic::MockedPagerDutyTest
       assert_equal(expected, got)
     end
 
+    it "should call parse on the plugin with a variant of the syntax" do
+      got = parse("911 sys subject unicorns are attacking", @plugin_manager)
+      expected = {team: "sys", plugin: "call", message: "unicorns are attacking"}
+      assert_equal(expected, got)
+    end
+
+    it "should consider because the same as subject" do
+      got = parse("911 someone else because unicorns are attacking", @plugin_manager)
+      expected = {team: "someone else", plugin: "call", message: "unicorns are attacking"}
+      assert_equal(expected, got)
+    end
+
     it "should call dispatch on the plugin" do
       query = {team: "sys", plugin: "call", message: "everything is on fire"}
 
@@ -48,7 +60,7 @@ class CallPlugin < Critic::MockedPagerDutyTest
       query = {team: "sys", plugin: "call", message: "everything is on fire"}
       @plugin_manager.loaded_plugins['email']
         .expects(:send_email)
-        .with do |email, message, _| 
+        .with do |email, message, _|
           email == "sys@moon.com" && message == "karl in #channel: #{query[:message]}"
         end
 

--- a/test/unit/pagerbot/plugins/call_person.rb
+++ b/test/unit/pagerbot/plugins/call_person.rb
@@ -31,7 +31,7 @@ class CallPerson < Critic::MockedPagerDutyTest
 
       it 'should parse query in example' do
         got = plugin.parse({
-          command: "get", 
+          command: "get",
           words: "karl subject you are needed in warroom".split
         })
         expected = {person: "karl", subject: "you are needed in warroom"}
@@ -40,12 +40,22 @@ class CallPerson < Critic::MockedPagerDutyTest
 
       it 'should consider because the same as subject' do
         got = plugin.parse({
-          command: "get", 
+          command: "get",
           words: "someone else because you are needed in warroom".split
         })
         expected = {person: "someone else", subject: "you are needed in warroom"}
         assert_equal(expected, got)
       end
+
+      it 'should still parse query when an explicit "subject"/"because" prefix is not present' do
+        got = plugin.parse({
+          command: "get",
+          words: "karl you are needed in warroom".split
+        })
+        expected = {person: "karl", subject: "you are needed in warroom"}
+        assert_equal(expected, got)
+      end
+
     end
 
     describe 'dispatch' do


### PR DESCRIPTION
Fixes https://github.com/stripe-contrib/pagerbot/issues/12

The explicit 'subject'/'because' is removed from documentation, but people can still use them for backward compatibility.

Caveats:
1. The message parsing code is no longer local (not fully stack-based) because it has to check if the word 'subject' or 'because' is present in `query[:words]`
2. Without an explicit 'subject'/'because' it won't recognize when the person's name consists of two words. This is an intended behavior.
3. The parser won't be able to tell if the "subject" in "help, mr. subject is drowning!" is part of the subject, not a keyword.
