### PR TITLE
Add feature to allow changing bot avatar in setup webface

### DIFF
--- a/public/views/bot.html
+++ b/public/views/bot.html
@@ -61,6 +61,13 @@
       Can be created <a href="https://api.slack.com/#auth">here.</a> Used to send private messages.
     </span>
   </p>
+  <p class="paragraph">
+    <label class="control-label">Bot emoji:</label>
+    <input ng-model="bot.slack.emoji" class="form-control short" placeholder=":frog:" />
+    <span class="input-description">
+      Emoji avatar for the bot.
+    </span>
+  </p>
 </section>
 
 <div class="section-header" ng-show="bot.adapter == 'irc'">


### PR DESCRIPTION
Let me know when it should have been `icon_url` instead of `icon_emoji`. With this, the code needs to be changed so that the latter is not set when the former is present.

Fixes https://github.com/stripe-contrib/pagerbot/issues/1
