### PR TITLE
Add rtm adapter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ PATH
       mongo
       rest-client
       sinatra
+      slack-rtmapi
       thin
 
 GEM
@@ -98,6 +99,8 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
+    slack-rtmapi (1.0.0.rc4)
+      websocket-driver
     slop (3.6.0)
     thin (1.6.3)
       daemons (~> 1.0, >= 1.0.9)
@@ -110,6 +113,9 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
+    websocket-driver (0.5.4)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
 
 PLATFORMS
   ruby

--- a/lib/admin/admin_server.rb
+++ b/lib/admin/admin_server.rb
@@ -13,6 +13,7 @@ include Mongo
 module PagerBot
   class AdminPage < Sinatra::Base
     set :public_folder, 'public'
+    set :bind, '0.0.0.0'
 
     helpers do
       def protected!

--- a/lib/pagerbot.rb
+++ b/lib/pagerbot.rb
@@ -39,9 +39,9 @@ module PagerBot
     log.info "msg=#{message.inspect}, extra_info=#{extra_info.inspect}"
     query = PagerBot::Parsing.parse(message, configatron.bot.name)
 
-    log.info query
+    log.info "query=#{query.inspect}"
     query[:schedule]=$1 if
-      /[#&]([^\x07\x2C\s]{,200})/ =~ extra_info[:channel_name] &&
+      /[#&]?([^\x07\x2C\s]{,200})/ =~ extra_info[:channel_name] &&
       query[:schedule]==""
 
     log.info "query=#{query.inspect}"

--- a/lib/pagerbot.rb
+++ b/lib/pagerbot.rb
@@ -14,6 +14,7 @@ require_relative './pagerbot/action_manager'
 require_relative './pagerbot/slack_adapter'
 require_relative './pagerbot/hipchat_adapter'
 require_relative './pagerbot/irc_adapter'
+require_relative './pagerbot/rtm_adapter'
 require_relative './pagerbot/plugin/plugin_manager'
 
 module PagerBot
@@ -110,10 +111,13 @@ if __FILE__ == $0
     elsif ARGV.first.include?('hipchat') || configatron.bot.adapter == 'hipchat'
       PagerBot::HipchatAdapter.run!
     end
+  elsif ARGV.first.include? 'rtm'
+    PagerBot.reload_configuration!
+    PagerBot::RtmAdapter.run!
   elsif ARGV.first.include? 'irc'
     PagerBot.reload_configuration!
     PagerBot::IrcAdapter.run!
   else
-    raise "Could not find adapter #{ARGV.first}. It must be either 'irc', 'slack' or 'hipchat'"
+    raise "Could not find adapter #{ARGV.first}. It must be one of 'irc', 'slack', 'rtm' or 'hipchat'"
   end
 end

--- a/lib/pagerbot.rb
+++ b/lib/pagerbot.rb
@@ -37,6 +37,12 @@ module PagerBot
 
     log.info "msg=#{message.inspect}, extra_info=#{extra_info.inspect}"
     query = PagerBot::Parsing.parse(message, configatron.bot.name)
+
+    log.info query
+    query[:schedule]=$1 if
+      /[#&]([^\x07\x2C\s]{,200})/ =~ extra_info[:channel_name] &&
+      query[:schedule]==""
+
     log.info "query=#{query.inspect}"
     answer = action_manager.dispatch(query, extra_info)
     log.info "answer=#{answer.inspect}"

--- a/lib/pagerbot/irc_adapter.rb
+++ b/lib/pagerbot/irc_adapter.rb
@@ -43,6 +43,7 @@ module PagerBot::IrcAdapter
         c.nick = configatron.bot.name
         c.password = configatron.bot.irc.fetch(:bot_password, nil) 
         c.server = configatron.bot.irc.server
+        c.port = configatron.bot.irc.port
         c.ssl.use = configatron.bot.irc.fetch(:use_ssl, false)
         # add a hash at the beginning if needed
         c.channels = configatron.bot.channels.map do |ch|

--- a/lib/pagerbot/parsing.rb
+++ b/lib/pagerbot/parsing.rb
@@ -54,7 +54,7 @@ module PagerBot::Parsing
 
     words.each do |word|
       case word
-      when 'for', 'on-call'
+      when 'for', /on(-|)call/, 'call'
         parse_stage = :schedule
       when 'on'
         if parse_stage == :schedule
@@ -100,7 +100,7 @@ module PagerBot::Parsing
       case word
       when 'is', 'am', 'are'
         parse_stage = :person
-      when 'on', 'for'
+      when 'on', 'for', /on(-|)call/, 'call'
         parse_stage = :schedule
       else
         person << word if parse_stage == :person

--- a/lib/pagerbot/parsing.rb
+++ b/lib/pagerbot/parsing.rb
@@ -54,6 +54,8 @@ module PagerBot::Parsing
 
     words.each do |word|
       case word
+      when 'for', 'on-call'
+        parse_stage = :schedule
       when 'on'
         if parse_stage == :schedule
           parse_stage = :time
@@ -62,7 +64,7 @@ module PagerBot::Parsing
         end
       when 'at', 'now'
         parse_stage = :time
-      when 'in'
+      when 'next', 'in', 'tomorrow', /\d+/
         parse_stage = :time
         time << word
       else
@@ -98,7 +100,7 @@ module PagerBot::Parsing
       case word
       when 'is', 'am', 'are'
         parse_stage = :person
-      when 'on'
+      when 'on', 'for'
         parse_stage = :schedule
       else
         person << word if parse_stage == :person

--- a/lib/pagerbot/rtm_adapter.rb
+++ b/lib/pagerbot/rtm_adapter.rb
@@ -1,0 +1,54 @@
+# Slack rtm integration for pagerbot
+
+require 'slack-rtmapi'
+require 'json'
+
+module PagerBot::RtmAdapter
+  class PagerDutyPlugin
+    def initialize(token, name)
+      @token = token
+      @name = name
+    end
+
+    def connect!
+      url = SlackRTM.get_url token: @token
+      @client = SlackRTM::Client.new websocket_url: url
+      @client.on(:message) { |data| process data }
+      @client.on(:error) { |data| raise Exception.new(data) }
+      @client.main_loop
+    end
+
+    def reply(m, answer)
+      data = {
+        text: answer[:message],
+        channel: m['channel'],
+        token: @token,
+        type: 'message',
+      }
+      p({data: data})
+      p @client.send(data)
+    end
+
+    def relevant?(m)
+      m['type'] == 'message' &&
+      m['text']=~/@?#{@name}:/
+    end 
+
+    def process(m)
+      return unless relevant? m
+      p({m: m})
+      answer = PagerBot.process(m['text'], {})
+      p({answer: answer})
+      reply(m, answer)
+    end
+  end
+
+  def self.run!
+    require 'pry'
+    token = configatron.bot.slack.api_token
+    name = configatron.bot.name
+    rtm = PagerDutyPlugin.new token, name
+    rtm.connect!
+    rtm
+  end
+end

--- a/lib/pagerbot/rtm_adapter.rb
+++ b/lib/pagerbot/rtm_adapter.rb
@@ -39,7 +39,7 @@ module PagerBot::RtmAdapter
 
     def relevant?(m)
       m['type'] == 'message' &&
-      m['text']=~/@?#{@name}:/
+      m['text']=~/^@?#{@name}:/
     end 
 
     def event_data(m)

--- a/pagerbot.gemspec
+++ b/pagerbot.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thin'
   spec.add_dependency 'mongo'
   spec.add_dependency 'bson_ext'
+  spec.add_dependency 'slack-rtmapi'
 
   spec.add_development_dependency 'minitest', '< 5.0'
   spec.add_development_dependency 'minitest-reporters'

--- a/templates/call_person_rtm.erb
+++ b/templates/call_person_rtm.erb
@@ -1,0 +1,1 @@
+Contacted <%=person.name%>, see <%=service_url%>.

--- a/templates/help_rtm.erb
+++ b/templates/help_rtm.erb
@@ -1,0 +1,18 @@
+I am <%= name %>, and I keep track of the pagers. You can ask me the following:
+
+  manual
+  help
+
+  list
+  people
+
+  who is on SCHEDULE [at TIME]
+  when [am I | is PERSON] on SCHEDULE
+
+<% loaded_plugins.each do |name, plugin| %>
+<% next unless plugin.responds_to? :manual %>
+<% plugin.manual.fetch(:syntax, []).each do |syntax| %>
+  <%= syntax %>
+
+<% end %>
+<% end %>

--- a/templates/lookup_person_rtm.erb
+++ b/templates/lookup_person_rtm.erb
@@ -1,0 +1,7 @@
+<% if time.nil? %>
+<%= person.name %> is not scheduled to go on <%= schedule.name %>
+<% elsif time < Time.now %>
+<%= person.name %> is on <%= schedule.name %> now
+<% else %>
+<%= person.name %> goes on call at <%= time %>
+<% end %>

--- a/templates/lookup_time_rtm.erb
+++ b/templates/lookup_time_rtm.erb
@@ -1,0 +1,5 @@
+<% unless start.nil? %>
+<%= person.name %> is on call at <%= start %>.
+<% else %>
+No-one is on call then for <%= schedule.name %>.
+<% end %>

--- a/templates/manual_rtm.erb
+++ b/templates/manual_rtm.erb
@@ -1,0 +1,35 @@
+I am <%= name %>. I keep track of the pagers. You can ask me the following:
+
+  *Get command usage:*
+    > help
+
+  *Get more detailed command usage:*
+    > manual
+
+  *List known schedules:*
+    > list
+
+  *List known people:*
+    > people
+
+  *Find out who is on call for a schedule:*
+    who is on SCHEDULE [at TIME]
+    > who is on primary breakage [at 2 pm]
+
+  *Find out when someone is on call:*
+    when [am I | is PERSON] on SCHEDULE
+    > when am I on triage
+    > when is llama on primary breakage
+<% loaded_plugins.each do |name, plugin| %>
+<% next unless plugin.responds_to? :manual %>
+
+  *<%= plugin.manual.fetch(:description) %>*
+<% plugin.manual.fetch(:syntax, []).each do |syntax| %>
+    <%= syntax %>
+
+<% end %>
+<% plugin.manual.fetch(:examples, []).each do |example| %>
+    > <%= example %>
+
+<% end %>
+<% end %>

--- a/templates/reload_rtm.erb
+++ b/templates/reload_rtm.erb
@@ -1,0 +1,23 @@
+<% if added_users.empty? && removed_users.empty? && added_schedules.empty? && removed_schedules.empty? %>
+Reload schedules and users, found nothing new.
+<% else %>
+<% unless added_users.empty? %>
+Added users: <%= added_users.map { |m| m.fetch(:name) }.join(", ") %>
+
+<% end %>
+<% unless removed_users.empty? %>
+Removed users: <%= removed_users.map { |m| m.fetch(:name) }.join(", ") %>
+
+<% end %>
+<% unless added_schedules.empty? %>
+Added schedules: <%= added_schedules.map { |m| m.fetch(:name) }.join(", ") %>
+
+<% end %>
+<% unless removed_schedules.empty? %>
+Removed schedules: <%= removed_schedules.map { |m| m.fetch(:name) }.join(", ") %>
+
+<% end %>
+<% unless added_users.empty? && removed_schedules.empty? %>
+You will need to add aliases for the new users/schedules. Use the alias command (see manual) or the web admin interface.
+<% end %>
+<% end %>

--- a/templates/schedule_override_rtm.erb
+++ b/templates/schedule_override_rtm.erb
@@ -1,0 +1,1 @@
+Ok. Put <%= person.name %> on <%= schedule.name %> from <%= from %> until <%= to %>

--- a/templates/switch_shift_rtm.erb
+++ b/templates/switch_shift_rtm.erb
@@ -1,0 +1,9 @@
+<% if shift_too_long %>
+The shift is longer than 30 hours, you probably want to do this via the admin interface! %>
+<% elsif fail_reason.nil? %>
+Ok, put <%= person.name %> on <%= schedule.name %> from <%= from %> to <%= to %>.
+<% elsif fail_reason == :not_on_call %>
+Sorry, but <%= shift_person.name %> is not on schedule on <%= Date.parse(day.to_s) %>.
+<% elsif fail_reason == :on_call_multiple_times %>
+Sorry, but <%= shift_person.name %> is on call multiple times on <%= Date.parse(day.to_s) %>.
+<% end %>


### PR DESCRIPTION
Adds an slack-rtm adapter. This differs from regular slack in that it does not need to be reached by slack. It sets up a long living connection with Slack over which messages are exchanged.
- Binds the admin page to 0.0.0.0 - I'm not sure if this would break heroku or not.
- Fixes a bug where the irc port was never set.
- Templates used from the irc adapter.
- Adds a 'guessing' feature where the service name is inferred from extra_info if parsing did not result in a service name. This allows for simpler interaction with the bot: `who is on-call?`, letting the context be inferred*.

\* This was a highly desired feature at our company since we have a lot of different teams with on-call, some with hard to remember names, such as`L1 follow the sun`. Adding an alias for channels which then map to this service allows for a lot of convenience.
