### PR TITLE
Parse decimal hours correctly.

### DIFF
--- a/lib/pagerbot/utilities.rb
+++ b/lib/pagerbot/utilities.rb
@@ -85,7 +85,7 @@ module PagerBot::Utilities
 
   # removes extra characters that pagerbot doesn't parse
   def self.normalize(text)
-    text.gsub(/[^-0-9A-Za-z:+' \/]/, '').downcase
+    text.gsub(/[^-0-9A-Za-z:+' \/\.]/, '').downcase
   end
 
   def self.time_link(time)

--- a/test/unit/pagerbot/plugins/schedule_override.rb
+++ b/test/unit/pagerbot/plugins/schedule_override.rb
@@ -30,6 +30,11 @@ class ScheduleOverridePlugin < Critic::MockedPagerDutyTest
               plugin: 'schedule_override', person: 'me', schedule: 'primary breakage',
               from: 'now', for: '3 hours'
             })
+          check_parse("#{word} me on primary breakage from now for 3.5 hours",
+            {
+              plugin: 'schedule_override', person: 'me', schedule: 'primary breakage',
+              from: 'now', for: '3.5 hours'
+            })
           check_parse("#{word} Jake on triage until 3 PM",
             {
               plugin: 'schedule_override', person: 'jake', schedule: 'triage',


### PR DESCRIPTION
R? @nelhage 

Before: `for: '35 hours'`
After: `for: '3.5 hours'`