### PR TITLE
Parse curly quotes like regular ones

### DIFF
--- a/lib/pagerbot/utilities.rb
+++ b/lib/pagerbot/utilities.rb
@@ -85,7 +85,7 @@ module PagerBot::Utilities
 
   # removes extra characters that pagerbot doesn't parse
   def self.normalize(text)
-    text.gsub(/[^-0-9A-Za-z:+' \/\.]/, '').downcase
+    text.gsub("\u2019", "'").gsub(/[^-0-9A-Za-z:+' \/\.]/, '').downcase
   end
 
   def self.time_link(time)

--- a/test/unit/pagerbot/plugins/switch_shift.rb
+++ b/test/unit/pagerbot/plugins/switch_shift.rb
@@ -58,6 +58,14 @@ class SwitchShiftPlugin < Critic::MockedPagerDutyTest
           })
       end
 
+      it "should parse curly quotes" do
+        check_parse("put karl on primary during john\u2019s shift on August 24th",
+          {
+            plugin: "switch_shift", person: "karl", whose_shift: "john",
+            day: "august 24th", schedule: "primary"
+          })
+      end
+
       it "should skip parsing the rest" do
         check_parse_fails("manual")
         check_parse_fails("who is on primary")


### PR DESCRIPTION
Slack on OS X auto-curlifies quotes, so this makes the shift switch plugin
work out of the box in that scenario.