### PR TITLE
Update the instructions for Slack integrations

### DIFF
--- a/public/views/bot.html
+++ b/public/views/bot.html
@@ -49,16 +49,19 @@
     <label class="control-label">Webhook token:</label>
     <input ng-model="bot.slack.webhook_token" class="form-control short" />
     <span class="input-description">
-      Outgoing webhook integration token used to check if queries really come from slack. If you're logged into slack, you can add one <a href="https://slack.com/services">here</a>.
-      <br />
-      On creation, set channels to <span class="highlight">any</span>, trigger word(s) to <span class="highlight">{{ bot.name }}</span> and URL(s) to <span class="highlight">{{ thisdomain }}</span>.
+      Log into Slack, go to <a href="https://sendwave.slack.com/apps/manage/custom-integrations">Custom Integrations</a>,
+      select "Outgoing WebHooks", and add a new configuration.
+      Set Channel to <span class="highlight">Any</span>, Trigger word(s) to <span class="highlight">{{ bot.name }}</span>, and URL(s) to <span class="highlight">{{ thisdomain }}</span>,
+      then paste the Token into the field above.
     </span>
   </p>
   <p class="paragraph">
     <label class="control-label">API token:</label>
     <input ng-model="bot.slack.api_token" class="form-control short" />
     <span class="input-description">
-      Can be created <a href="https://api.slack.com/#auth">here.</a> Used to send private messages.
+      Log into Slack, go to <a href="https://sendwave.slack.com/apps/manage/custom-integrations">Custom Integrations</a>,
+      select "Bots", and add a new configuration.
+      Paste the API Token into the field above.
     </span>
   </p>
   <p class="paragraph">


### PR DESCRIPTION
I had to hunt around a bit when setting up Pagerbot today.  It looks like the Slack URLs and UI have changed a little bit since the instructions were originally written.