### PR TITLE
Fix Heroku build by omitting TODO from gemspec description

### DIFF
--- a/pagerbot.gemspec
+++ b/pagerbot.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Karl-Aksel Puulmann']
   spec.email         = ['oxymaccy@gmail.com']
   spec.summary       = %q{IRC and Slackbot for PagerDuty.}
-  spec.description   = %q{TODO: Write a longer description. Optional.}
+  spec.description   = %q{This bot connects Slack or IRC to PagerDuty.}
   spec.homepage      = 'https://github.com/stripe-contrib/pagerbot'
   spec.license       = 'MIT'
 


### PR DESCRIPTION
When attempting to deploy to Heroku right now, I got the following error. Removing TODO from the gemspec description was sufficient to fix it and finish the deploy. :)

-----> Fetching set buildpack https://github.com/heroku/heroku-buildpack-ruby... done
-----> Ruby app detected
-----> Compiling Ruby/Rack
 !
 !     There was an error parsing your Gemfile, we cannot continue
 !     fatal: Not a git repository (or any parent up to mount point /tmp)
 !     Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
 !     The gemspec at
 !     /tmp/build_685a5f3a3f694c2245d8b1c9795b0080/stripe-contrib-pagerbot-fe40c3b/pagerbot.gemspec
 !     is not valid. Please fix this gemspec.
 !     The validation error was '"FIXME" or "TODO" is not a description'
 !
 !     Push rejected, failed to compile Ruby app