### PR TITLE
Add emails as an index for pagerbot users.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+before_install:
+  - gem install bundler
+
 language: ruby
 rvm:
   - 1.9.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pagerbot (0.2.0)
+    pagerbot (0.3.0)
       activesupport
       bson_ext
       chronic
@@ -124,3 +124,6 @@ DEPENDENCIES
   pry
   rake
   rerun
+
+BUNDLED WITH
+   1.13.1

--- a/lib/pagerbot/models.rb
+++ b/lib/pagerbot/models.rb
@@ -53,6 +53,16 @@ module PagerBot
 
         @list.each do |member|
           add_index(member.id, member)
+
+          # add email as an index for users
+          if member.is_a?(User)
+            norm_email = member.email.split('@').first
+            if has_index?(norm_email)
+              PagerBot.log.warn("Adding ambiguous email alias: #{norm_email} for #{member.email}")
+            end
+            add_index(norm_email, member)
+          end
+
           member.aliases = member.aliases.select do |alias_|
             norm_alias = normalize(alias_['name'])
             unless ambiguous.include? norm_alias
@@ -65,6 +75,10 @@ module PagerBot
 
       def add_index(key, value)
         @index[normalize(key)] = value
+      end
+
+      def has_index?(key)
+        @index.key?(normalize(key))
       end
     end
 

--- a/pagerbot.gemspec
+++ b/pagerbot.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Karl-Aksel Puulmann']
   spec.email         = ['oxymaccy@gmail.com']
   spec.summary       = %q{IRC and Slackbot for PagerDuty.}
-  spec.description   = %q{TODO: Write a longer description. Optional.}
+  spec.description   = %q{This bot connects Slack or IRC to PagerDuty.}
   spec.homepage      = 'https://github.com/stripe-contrib/pagerbot'
   spec.license       = 'MIT'
 

--- a/pagerbot.gemspec
+++ b/pagerbot.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'pagerbot'
-  spec.version       = '0.2.0'
+  spec.version       = '0.3.0'
   spec.authors       = ['Karl-Aksel Puulmann']
   spec.email         = ['oxymaccy@gmail.com']
   spec.summary       = %q{IRC and Slackbot for PagerDuty.}


### PR DESCRIPTION
Pagerbot, by default, only indexes on PagerDuty IDs and aliases.
Since Pagerduty emails are likely to be at least somewhat unique,
add those in as a default index, too.

r? @rhwlo