### PR TITLE
Make call_person plugin able to page schedules too

### DIFF
--- a/lib/pagerbot/action_manager.rb
+++ b/lib/pagerbot/action_manager.rb
@@ -3,7 +3,7 @@ module PagerBot
   class ActionManager
     extend MethodDecorators
     attr_reader :pagerduty, :plugin_manager, :current_adapter
-    
+
     def initialize(options)
       @options = options
       @pagerduty = PagerBot::PagerDuty.new(options.fetch(:pagerduty))
@@ -69,7 +69,7 @@ module PagerBot
 
     +PagerBot::Utilities::DispatchMethod
     def manual(query, event_data)
-      { 
+      {
         message: "Sending you the manual in a PM.",
         private_message: render('manual', loaded_plugins: plugin_manager.loaded_plugins, name: @options[:bot][:name])
       }
@@ -99,12 +99,12 @@ module PagerBot
       entries = schedule_info[:schedule][:final_schedule][:rendered_schedule_entries]
       vars = {
         schedule: schedule,
-        start: nil
+        start: time,
+        person: nil
       }
       if entries.length > 0
         oncall = entries.first
         vars[:person] = @pagerduty.users.get(oncall[:user][:id])
-        vars[:start] = vars[:person].parse_time(oncall[:start])
       end
       render "lookup_time", vars
     end

--- a/lib/pagerbot/action_manager.rb
+++ b/lib/pagerbot/action_manager.rb
@@ -89,14 +89,14 @@ module PagerBot
       # who is on primary?
       schedule = @pagerduty.find_schedule(query[:schedule])
       time = @pagerduty.parse_time(query[:time], event_data[:nick], guess: :middle)
-      users = @pagerduty.get_schedule_oncall(schedule.id, time)
+      oncall_users = @pagerduty.get_schedule_oncall(schedule.id, time)
       vars = {
         schedule: schedule,
         start: time,
         person: nil
       }
-      if users.length > 0
-        vars[:person] = @pagerduty.users.get(users[0][:id])
+      if oncall_users.length > 0
+        vars[:person] = @pagerduty.users.get(oncall_users[0][:id])
       end
       render "lookup_time", vars
     end

--- a/lib/pagerbot/pagerduty.rb
+++ b/lib/pagerbot/pagerduty.rb
@@ -94,6 +94,27 @@ module PagerBot
       return schedule
     end
 
+    # Returns a list like:
+    # [
+    #   {
+    #     id: "ABCDEF",
+    #     name: "Dan Benamy",
+    #     email: "daniel@benamy.info",
+    #     color: "orange"
+    #   }
+    # ]
+    def get_schedule_oncall(schedule_id, time)
+      response = get(
+        "/schedules/#{schedule_id}",
+        :params => {
+          :since => time.iso8601,
+          :until => (time + 1).iso8601
+      })
+      response[:schedule][:final_schedule][:rendered_schedule_entries].map do |x|
+        x[:user]
+      end
+    end
+
     def next_oncall(person_id, schedule_id)
       response = get(
         "/schedules/#{schedule_id}",

--- a/lib/pagerbot/plugin/call_person.rb
+++ b/lib/pagerbot/plugin/call_person.rb
@@ -2,7 +2,7 @@ module PagerBot::Plugins
   class CallPerson
     include PagerBot::PluginBase
     responds_to :queries, :manual
-    description "Send a page directly to a person."
+    description "Page a person by nick or schedule. Needs a scratch schedule, escalation policy, and service."
     required_fields "schedule_id", "service_id"
 
     def initialize(config)
@@ -13,29 +13,31 @@ module PagerBot::Plugins
 
     def self.manual
       {
-        description: "Trigger a call to a person",
-        syntax: ["get PERSON [SUBJECT]"],
-        examples: ["get karl you are needed in warroom"]
+        description: "Page a person by nick or schedule (which could be a team)",
+        syntax: ["get PERSON|SCHEDULE [SUBJECT]"],
+        examples: [
+          "get karl you are needed in warroom",
+          "get sre the load balancers are down"
+        ]
       }
     end
 
     def parse(query)
-      # get karl because everything is on fire
       return unless query[:command] == "get"
 
-      person = []
+      to = []
       subject = []
       implicit_subject = (query[:words] & ['subject', 'because']).empty?
 
-      parse_stage = :person
+      parse_stage = :to
       query[:words].each do |word|
         case word
         when 'subject', 'because'
           parse_stage = :subject
         else
           case parse_stage
-          when :person
-            person << word
+          when :to
+            to << word
             if implicit_subject
               parse_stage = :subject
             end
@@ -44,7 +46,7 @@ module PagerBot::Plugins
         end
       end
       {
-        person: person.join(" "),
+        to: to.join(" "),
         subject: subject.join(" ")
       }
     end
@@ -67,11 +69,14 @@ module PagerBot::Plugins
 
     +PagerBot::Utilities::DispatchMethod
     def dispatch(query, event_data)
-      # hacky flow since API doesn't support creating an incident directly against a user
-      # - put person on call on schedule for 3 minutes
+      # hacky flow since API doesn't support creating an incident directly
+      # against a user:
+      # - put person on call on schedule for 5 minutes
       # - trigger incident
-      person = pagerduty.find_user(query[:person], event_data[:nick])
-      start = person.parse_time("now")
+      person_name, person_uid = person(query[:to], event_data[:nick])
+      log.info("Found #{person_name} #{person_uid}")
+
+      start = Time.now()
       # People still get pinged even if they're not on call,
       # so this is a safety measure.
       to = start + ChronicDuration.parse("5 minutes")
@@ -82,13 +87,13 @@ module PagerBot::Plugins
           :override => {
             :start => start.iso8601,
             :end => to.iso8601,
-            :user_id => person.id.to_s
+            :user_id => person_uid
           }
         },
         :content_type => :json
       )
 
-      log.info "Put #{person.name} on temporary schedule for 5 minutes. #{override}"
+      log.info "Put #{person_name} on temporary schedule for 5 minutes. #{override}"
 
       incident = post_incident(
         :service_key => @service[:service_key],
@@ -96,11 +101,30 @@ module PagerBot::Plugins
         :description => query[:subject]
       )
 
-      log.info "Created incident for #{person.name}. #{incident.inspect}"
+      log.info "Created incident for #{person_name}. #{incident.inspect}"
       # RAGE: Of course incident doesn't include the id of the incident created.
       service_url = "#{pagerduty.uri_base}#{@service[:service_url]}"
 
-      render "call_person", {person: person, service_url: service_url}
+      render "call_person", {person_name: person_name, service_url: service_url}
+    end
+
+    def person(nick_or_schedule, requestor)
+      begin
+        person = pagerduty.find_user(nick_or_schedule, requestor)
+        return person.name, person.id
+      rescue Pagerbot::UserNotFoundError => e
+        log.info("Didn't find person '#{nick_or_schedule}'. Looking via schedule.")
+        schedule = pagerduty.find_schedule(nick_or_schedule)
+        if schedule.nil?
+          raise RuntimeError.new(
+            "Couldn't find a person or schedule named '#{nick_or_schedule}'")
+        end
+        users = pagerduty.get_schedule_oncall(schedule.id, Time.now())
+        if users.length == 0
+          raise RuntimeError.new("No one is on call for #{nick_or_schedule}")
+        end
+        return users[0][:name], users[0][:id]
+      end
     end
   end
 end

--- a/templates/call_person_irc.erb
+++ b/templates/call_person_irc.erb
@@ -1,1 +1,1 @@
-Contacted <%=person.name%>, see <%=service_url%>.
+Contacted <%= person_name %>, see <%= service_url %>.

--- a/templates/call_person_slack.erb
+++ b/templates/call_person_slack.erb
@@ -1,1 +1,1 @@
-Contacted <%=person.name%>, see the incident created <%= utilities.link_to(service_url, 'here') %>.
+Contacted <%= person_name %>, see the incident created <%= utilities.link_to(service_url, 'here') %>.

--- a/templates/lookup_time_irc.erb
+++ b/templates/lookup_time_irc.erb
@@ -1,5 +1,1 @@
-<% unless start.nil? %>
-<%= person.name %> is on call at <%= start %>.
-<% else %>
-No-one is on call then for <%= schedule.name %>.
-<% end %>
+<% unless person.nil? %><%= person.name %><% else %>No-one<% end %> is on call at <%= start %> for <%= schedule.name %>.

--- a/templates/lookup_time_slack.erb
+++ b/templates/lookup_time_slack.erb
@@ -1,5 +1,1 @@
-<% unless start.nil? %>
-<%= person.name %> is on call at <%= utilities.display_time start %>. <%= utilities.display_schedule(schedule, 'View Schedule') %>
-<% else %>
-No-one is on call then. <%= utilities.display_schedule(schedule, 'View Schedule') %>
-<% end %>
+<% unless person.nil? %><%= person.name %><% else %>No-one<% end %> is on call at <%= utilities.display_time start %>. <%= utilities.display_schedule(schedule, 'View Schedule') %>

--- a/test/unit/pagerbot/action_manager.rb
+++ b/test/unit/pagerbot/action_manager.rb
@@ -6,7 +6,7 @@ class ActionManager < Critic::MockedPagerDutyTest
     opts
   end
 
-  before do 
+  before do
     @manager = PagerBot::ActionManager.new(
       :pagerduty => @pagerduty_settings,
       :bot => @bot_settings)
@@ -108,19 +108,30 @@ class ActionManager < Critic::MockedPagerDutyTest
     end
 
     describe 'who is on schedule X' do
-      it 'should work on happy path' do
+      it 'returns the person on call and uses the requestors timezone' do
         @pagerduty.expects(:get)
+          .twice
           .with { |url, _, _| url == '/schedules/PRIMAR1' }
           .returns(@fake_schedule)
 
         query = {schedule: "primary", time: "3 PM"}
-        val = @manager.lookup_time(query, event_data).fetch(:message)
-        # answer from perspective of the person. 
-        # query was from GMT-7, which adds 7 hours to the original time
-        assert_equal("Karl-Aksel Puulmann is on call at 2014-07-28 22:00:00 +0000.", val)
+        # Query as john who's set to eastern in the local db which is UTC-0400
+        # or -0500, depending on the time of year.
+        val = @manager.lookup_time(query, {nick: 'john'}).fetch(:message)
+        # The date varies so don't include it in the assertion.
+        assert_match(
+          /Karl-Aksel Puulmann is on call at .* 15:00:00 -0[45]00 for Primary breakage/,
+          val)
+
+        # And now query again as karl, who's set to UTC (in the db; this ignores
+        # the tz in the pagerduty schedule api response).
+        val = @manager.lookup_time(query, {nick: 'karl'}).fetch(:message)
+        assert_match(
+          /Karl-Aksel Puulmann is on call at .* 15:00:00 \+0000 for Primary breakage/,
+          val)
       end
 
-      it 'noone on schedule' do
+      it 'returns no one on schedule' do
         @fake_schedule[:schedule][:final_schedule][:rendered_schedule_entries] = []
         @pagerduty.expects(:get)
           .with { |url, _, _| url == '/schedules/PRIMAR1' }
@@ -128,8 +139,9 @@ class ActionManager < Critic::MockedPagerDutyTest
 
         query = {schedule: "primary", time: "3 PM"}
         val = @manager.lookup_time(query, event_data).fetch(:message)
-
-        assert_equal("No-one is on call then for Primary breakage.", val)
+        assert_match(
+          /No-one is on call at .* 15:00:00 \+0000 for Primary breakage/,
+          val)
       end
     end
 

--- a/test/unit/pagerbot/plugins/call_person.rb
+++ b/test/unit/pagerbot/plugins/call_person.rb
@@ -34,7 +34,7 @@ class CallPerson < Critic::MockedPagerDutyTest
           command: "get",
           words: "karl subject you are needed in warroom".split
         })
-        expected = {person: "karl", subject: "you are needed in warroom"}
+        expected = {to: "karl", subject: "you are needed in warroom"}
         assert_equal(expected, got)
       end
 
@@ -43,7 +43,7 @@ class CallPerson < Critic::MockedPagerDutyTest
           command: "get",
           words: "someone else because you are needed in warroom".split
         })
-        expected = {person: "someone else", subject: "you are needed in warroom"}
+        expected = {to: "someone else", subject: "you are needed in warroom"}
         assert_equal(expected, got)
       end
 
@@ -52,14 +52,15 @@ class CallPerson < Critic::MockedPagerDutyTest
           command: "get",
           words: "karl you are needed in warroom".split
         })
-        expected = {person: "karl", subject: "you are needed in warroom"}
+        expected = {to: "karl", subject: "you are needed in warroom"}
         assert_equal(expected, got)
       end
-
     end
 
     describe 'dispatch' do
-      before do
+      it 'should not error with standard responses' do
+        plug = plugin # just load it once
+
         PagerBot::PagerDuty.any_instance
           .expects(:post)
           .with { |url, params, _|
@@ -68,22 +69,99 @@ class CallPerson < Critic::MockedPagerDutyTest
           }
           .returns({})
 
-        @plugin = plugin
-        @plugin
+        plug
           .expects(:post_incident)
           .with({
             :event_type => "trigger",
             :service_key => "fake_service_key",
-            :description => "description description"
+            :description => "there's not enough pizza"
           })
-      end
 
-      it 'should not error with standard responses' do
-        answer = @plugin.dispatch({
-          person: "me", subject: "description description"
+        answer = plug.dispatch({
+          to: "me", subject: "there's not enough pizza"
         }, {nick: "karl"}).fetch(:message)
         assert_includes(answer, "Contacted Karl-Aksel Puulmann, see ")
         assert_includes(answer, "pagerduty.com/services/PFAKESRV")
+      end
+
+      it "should look up by schedule if a person isn't found" do
+        plug = plugin # just load it once
+
+        mock_sched = Object.new()
+        mock_sched.stubs(:id).returns('SCHED123')
+        PagerBot::PagerDuty.any_instance
+          .expects(:find_schedule)
+          .with { |name| name == 'sre' }
+          .returns(mock_sched)
+
+        PagerBot::PagerDuty.any_instance
+          .expects(:get_schedule_oncall)
+          .with { |schedule_id, _, _| schedule_id == 'SCHED123' }
+          .returns([{id: 'P123456', name: 'Bob'}])
+
+        PagerBot::PagerDuty.any_instance
+          .expects(:post)
+          .with { |url, params, _|
+            url == "/schedules/PFAKESCHED/overrides" &&
+            params[:override][:user_id] == "P123456"
+          }
+          .returns({})
+
+        plug
+          .expects(:post_incident)
+          .with({
+            :event_type => "trigger",
+            :service_key => "fake_service_key",
+            :description => "there's too much pizza"
+          })
+
+        answer = plug.dispatch({
+          to: "sre", subject: "there's too much pizza"
+        }, {nick: "karl"}).fetch(:message)
+        assert_includes(answer, "Contacted Bob, see ")
+        assert_includes(answer, "pagerduty.com/services/PFAKESRV")
+      end
+
+      it "should return a userful error if no one's on call for the schedule" do
+        mock_sched = Object.new()
+        mock_sched.stubs(:id).returns('SCHED123')
+        PagerBot::PagerDuty.any_instance
+          .expects(:find_schedule)
+          .with { |name| name == 'sre' }
+          .returns(mock_sched)
+
+        PagerBot::PagerDuty.any_instance
+          .expects(:get_schedule_oncall)
+          .with { |schedule_id, _, _| schedule_id == 'SCHED123' }
+          .returns([])
+
+        begin
+          plugin.dispatch({
+            to: "sre", subject: "the system is down, down down down down"
+          }, {nick: "karl"}).fetch(:message)
+        rescue => e
+          assert_includes(e.to_s, "No one is on call for sre")
+        else
+          assert(false, "Shouldn't get here.")
+        end
+      end
+
+      it 'should return a useful error if neither person nor schedule is found' do
+        PagerBot::PagerDuty.any_instance
+          .expects(:find_schedule)
+          .with { |name| name == "schedule-that-doesn't-exist" }
+          .returns(nil)
+
+        begin
+          plugin.dispatch({
+            to: "schedule-that-doesn't-exist",
+            subject: "the system is down, down down down down"
+          }, {nick: "karl"}).fetch(:message)
+        rescue => e
+          assert_includes(e.to_s, "Couldn't find a person or schedule")
+        else
+          assert(false, "Shouldn't get here.")
+        end
       end
     end
   end


### PR DESCRIPTION
This makes paging teams (or other groups) easier to set up, easier to use, faster to execute, and less error prone, than using the `call` (911) plugin for this.

Each commit is a self contained chunk to make reviewing easier, although it may not be obvious why I made the change until you see the following one(s).