### PR TITLE
Use pagerduty v2 api response to paginate, since v1 is deprecated

### DIFF
--- a/lib/pagerbot/utilities.rb
+++ b/lib/pagerbot/utilities.rb
@@ -10,13 +10,13 @@ module PagerBot::Utilities
 
     loop do
       resp = pagerduty.get(endpoint, :params => {
-        :offset => offset, :limit => 200 })
+        :offset => offset, :limit => 100 })
       resp[collection_name].each do |item|
         result[item[:id]] = item
       end
 
       offset += resp[collection_name].length
-      break if offset >= resp[:total]
+      break unless resp[:more]
     end
     result
   end


### PR DESCRIPTION
- Use more field as per https://v2.developer.pagerduty.com/docs/pagination: 
> "more": true, // indicates if there are more resources available than were returned

- Update limit to 100, since max allowed is 100. As per https://v2.developer.pagerduty.com/docs/pagination : 
> You can override this by passing a limit parameter to set the maximum number of results, but cannot exceed 100.