### PR TITLE
Allow a custom help message.

### DIFF
--- a/lib/pagerbot/action_manager.rb
+++ b/lib/pagerbot/action_manager.rb
@@ -80,6 +80,7 @@ module PagerBot
       render(
         'help',
         loaded_plugins: plugin_manager.loaded_plugins,
+        help_message: @options[:bot][:help_message],
         name: @options[:bot][:name])
     end
 

--- a/public/views/bot.html
+++ b/public/views/bot.html
@@ -31,6 +31,14 @@
     </span>
   </p>
 
+  <p class="paragraph">
+    <label class="control-label">Help message:</label>
+    <input ng-model="bot.help_message" class="form-control short" />
+    <span class="input-description">
+      An optional extra message to be included in the bot help output. Useful for site specific details.
+    </span>
+  </p>
+
   <div class="paragraph" ng-if="bot.adapter != 'slack-rtm'">
     <label class="control-label">Channels:</label>
 

--- a/templates/help_irc.erb
+++ b/templates/help_irc.erb
@@ -16,3 +16,5 @@ I am <%= name %>, and I keep track of the pagers. You can ask me the following:
 
 <% end %>
 <% end %>
+<% if help_message.present? %>
+<%= help_message %><% end %>

--- a/test/unit/pagerbot/action_manager.rb
+++ b/test/unit/pagerbot/action_manager.rb
@@ -142,6 +142,18 @@ class ActionManager < Critic::MockedPagerDutyTest
         assert_includes(help_text, 'list')
         assert_includes(help_text, 'people')
       end
+
+      it 'should include help link if provided' do
+        @bot_settings[:help_message] = "https://example.com/help"
+        @manager = PagerBot::ActionManager.new(
+          :pagerduty => @pagerduty_settings,
+          :bot => @bot_settings)
+        @pagerduty = @manager.instance_variable_get("@pagerduty")
+
+        help_text = @manager.dispatch({type: 'help'}, event_data)[:message]
+
+        assert_includes(help_text, 'https://example.com/help')
+      end
     end
 
     describe 'manual' do


### PR DESCRIPTION
Hello! Thank you for this bot, it's fantastic. I wanted to add some site-specific text to `pagerbot help` directing people to our runbook (such as if their schedule isn't showing up or something like that).

<img width="672" alt="screen shot 2017-01-10 at 5 02 17 pm" src="https://cloud.githubusercontent.com/assets/1714/21831305/93b6d5e6-d757-11e6-8644-84ebe6977af6.png">

<img width="688" alt="slack_-_square" src="https://cloud.githubusercontent.com/assets/1714/21831316/bc7b2130-d757-11e6-94db-05acfcddb22c.png">

Thank you for considering my patch. Any feedback welcome!