### PR TITLE
Fix module typo

### DIFF
--- a/lib/pagerbot/slack_adapter.rb
+++ b/lib/pagerbot/slack_adapter.rb
@@ -60,7 +60,7 @@ module PagerBot
              configatron.bot.channels.include?(request[:channel_name])
         return ""
       end
-      text = Pagerbot::Parsing.strip_names(params[:text], [configatron.bot.name])
+      text = PagerBot::Parsing.strip_names(params[:text], [configatron.bot.name])
       return "" if text.nil?
 
       params = event_data request


### PR DESCRIPTION
This really should be covered by a test, sorry I don't have time to do that myself.

Without this, any request causes

```
2017-01-23T19:00:28.900703+00:00 app[web.1]: INFO /app/lib/pagerbot/slack_adapter.rb:55:in `block in <class:SlackAdapter>': {:token=>"REDACTED", :nick=>"xavier", :channel_name=>"testing", :text=>"pagerbot help", :user_id=>"REDACTED", :adapter=>:slack}
2017-01-23T19:00:28.900965+00:00 app[web.1]: 2017-01-23 19:00:28 - NameError - uninitialized constant Pagerbot::Parsing:
2017-01-23T19:00:28.900966+00:00 app[web.1]: 	/app/lib/pagerbot/slack_adapter.rb:63:in `block in <class:SlackAdapter>'
2017-01-23T19:00:28.900968+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.2.0/gems/sinatra-1.4.7/lib/sinatra/base.rb:1611:in `call'
```