### PR TITLE
Add papertrail addon to deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ To deploy it to heroku, git clone, create a heroku app and push to launch it.
 ```bash
 heroku create
 heroku addons:add mongolab:sandbox
+heroku addons:add papertrail
 git push heroku master
 ```
 


### PR DESCRIPTION
Add instructions for papertrail so that logging works with manual deployments.