### PR TITLE
Readme instructions for non docker setup 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,26 @@ docker-compose up --build pagerbot-admin
 docker-compose up --build pagerbot
 ```
 
+If you want to play with this in the console, follow the steps below
+
+```bash
+  bundle install
+  # Open up localhost:4567, where you can set up pagerduty and bot credentials. Necessary for testing functionality on the console/bot. Scrolling through different pages, will populate your mongo database with users and schedules.
+  ruby lib/pagerbot.rb admin
+  # Run the bot itself locally
+  ruby lib/pagerbot.rb
+```
+
+Within the irb
+```ruby
+  require_relative 'lib/pagerbot'
+  require_relative 'lib/admin/admin_server'
+  PagerBot.reload_configuration!
+  # For example:
+  PagerBot.process("who is on primary now?", {:nick=>"username", :adapter=>:slack})
+```
+
+
 Deploying via heroku
 =======
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Within the irb
   PagerBot.process("who is on primary now?", {:nick=>"username", :adapter=>:slack})
 ```
 
-
 Deploying via heroku
 =======
 


### PR DESCRIPTION
The following instructions allow for an alternate docker-free setup, and imo also make it easier to dev test this on the console with. 

I'm interested to hear your thoughts if you think its worth adding this to the README. I assume I could just shell into a docker container and execute the same commands?