### PR TITLE
Upgrade to Ruby 2.5.1 Support, avoid seg faults from old activesupport package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ before_install:
 
 language: ruby
 rvm:
-  - 2.0.0
-  - 2.1.0
-  - 2.2.0
-  - 2.3.0
+  - 2.5.1
 # command to run tests
 script: "bundle exec rake test"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.2
+FROM ruby:2.5
 
 RUN apt-get update; apt-get install libgmp3-dev --assume-yes
 RUN mkdir /pagerbot

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 # Execute bundler hook if present
 source('https://rubygems.org/')
+
+ruby '>=2.5.1'
 # Specify your gem's dependencies in pagerbot.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       configatron
       eventmachine
       faye-websocket
-      mailgun-ruby (= 1.1.2)
+      mailgun-ruby
       method_decorators
       mongo (> 2.0)
       rest-client
@@ -22,118 +22,117 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.0.13)
-      i18n (~> 0.6, >= 0.6.9)
-      minitest (~> 4.2)
-      multi_json (~> 1.3)
-      thread_safe (~> 0.1)
-      tzinfo (~> 0.3.37)
+    activesupport (5.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     ansi (1.5.0)
-    bson (4.2.1)
+    bson (4.3.0)
     bson_ext (1.5.1)
     builder (3.2.3)
-    celluloid (0.15.2)
-      timers (~> 1.1.0)
+    celluloid (0.16.0)
+      timers (~> 4.0.0)
     chronic (0.10.2)
     chronic_duration (0.10.6)
       numerizer (~> 0.1.1)
-    cinch (2.3.3)
-    coderay (1.1.1)
-    concurrent-ruby (1.0.4)
-    configatron (4.5.0)
-    daemons (1.2.4)
-    domain_name (0.5.20161129)
+    cinch (2.3.4)
+    coderay (1.1.2)
+    concurrent-ruby (1.0.5)
+    configatron (4.5.1)
+    daemons (1.2.6)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.2.0)
-    eventmachine (1.2.2)
-    faraday (0.11.0)
+    dotenv (2.5.0)
+    eventmachine (1.2.7)
+    faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.11.0.1)
+    faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
-    faye-websocket (0.10.6)
+    faye-websocket (0.10.7)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
-    ffi (1.9.17)
-    gli (2.15.0)
-    hashie (3.5.1)
+    ffi (1.9.25)
+    gli (2.18.0)
+    hashie (3.6.0)
+    hitimes (1.3.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (0.8.0)
-    json (2.0.3)
-    listen (2.7.9)
-      celluloid (>= 0.15.2)
+    i18n (1.1.0)
+      concurrent-ruby (~> 1.0)
+    listen (2.10.1)
+      celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-    mailgun-ruby (1.1.2)
+    mailgun-ruby (1.1.10)
       rest-client (~> 2.0)
     metaclass (0.0.4)
     method_decorators (0.9.6)
-    method_source (0.8.2)
-    mime-types (3.1)
+    method_source (0.9.0)
+    mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
-    minitest (4.7.5)
-    minitest-reporters (0.14.24)
+    mime-types-data (3.2018.0812)
+    minitest (5.11.3)
+    minitest-reporters (1.3.4)
       ansi
       builder
-      minitest (>= 2.12, < 5.0)
-      powerbar
-    mocha (1.2.1)
+      minitest (>= 5.0)
+      ruby-progressbar
+    mocha (1.7.0)
       metaclass (~> 0.0.1)
-    mongo (2.4.1)
-      bson (>= 4.2.1, < 5.0.0)
-    multi_json (1.12.1)
+    mongo (2.6.2)
+      bson (>= 4.3.0, < 5.0.0)
     multipart-post (2.0.0)
+    mustermann (1.0.3)
     netrc (0.11.0)
     numerizer (0.1.1)
-    powerbar (1.0.18)
-      hashie (>= 1.1.0)
-    pry (0.10.4)
+    pry (0.11.3)
       coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-    rack (1.6.5)
-    rack-protection (1.5.3)
+      method_source (~> 0.9.0)
+    rack (2.0.5)
+    rack-protection (2.0.4)
       rack
-    rake (12.0.0)
-    rb-fsevent (0.9.8)
-    rb-inotify (0.9.8)
-      ffi (>= 0.5.0)
+    rake (12.3.1)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
     rerun (0.10.0)
       listen (~> 2.7, >= 2.7.3)
-    rest-client (2.0.0)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    semantic_logger (3.4.1)
+    ruby-progressbar (1.10.0)
+    semantic_logger (4.3.0)
       concurrent-ruby (~> 1.0)
-    sinatra (1.4.8)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
-    slack-ruby-client (0.7.9)
+    sinatra (2.0.4)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.4)
+      tilt (~> 2.0)
+    slack-ruby-client (0.13.0)
       activesupport
       faraday (>= 0.9)
       faraday_middleware
       gli
       hashie
-      json
       websocket-driver
-    slop (3.6.0)
-    thin (1.7.0)
+    thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
-    thread_safe (0.3.5)
-    tilt (2.0.6)
-    timers (1.1.0)
-    tzinfo (0.3.52)
+    thread_safe (0.3.6)
+    tilt (2.0.8)
+    timers (4.0.4)
+      hitimes
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
-    websocket-driver (0.6.5)
+    unf_ext (0.0.7.5)
+    websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
+    websocket-extensions (0.1.3)
 
 PLATFORMS
   ruby
@@ -141,7 +140,7 @@ PLATFORMS
 DEPENDENCIES
   bundler
   dotenv
-  minitest (< 5.0)
+  minitest
   minitest-reporters
   mocha
   pagerbot!
@@ -149,5 +148,8 @@ DEPENDENCIES
   rake
   rerun (~> 0.10.0)
 
+RUBY VERSION
+   ruby 2.5.1p57
+
 BUNDLED WITH
-   1.13.7
+   1.16.4

--- a/pagerbot.gemspec
+++ b/pagerbot.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'configatron'
   spec.add_dependency 'eventmachine' # Used by slack-ruby-client
   spec.add_dependency 'faye-websocket' # Used by slack-ruby-client
-  spec.add_dependency 'mailgun-ruby', '1.1.2'
+  spec.add_dependency 'mailgun-ruby'
   spec.add_dependency 'method_decorators'
   spec.add_dependency 'mongo', '> 2.0'
   spec.add_dependency 'rest-client'
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'slack-ruby-client'
   spec.add_dependency 'thin'
 
-  spec.add_development_dependency 'minitest', '< 5.0'
+  spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'minitest-reporters'
   spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'dotenv'


### PR DESCRIPTION
I had issues deploying this on a heroku-18 stack with the version of ruby defined. Segfaults were occurring from a 4.0.3 `activesupport` dependency, supplied by the ruby package system when using the defined ruby versions (2.2? 2.3?). 

This pull request upgrades everything to 2.5.1 ruby, including all of its dependencies. 

Tests pass after rebuilding the dockerimage (updated to extend from RUBY:2.5) 

Let me know if there's a better way of defining these version restrictions. It's possible it might work with 2.4 well, but I haven't had the time to try. The ruby buildpack does not support Ruby 2.3 running on the latest stack (heroku-18).